### PR TITLE
Support methods returning multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3.1
+
+Added support for methods returning multiple values.
+
 # 0.1.3.0
 
 Module DBus.TH renamed to DBus.TH.EDSL for compatibility with dbus-1.0.1 package.

--- a/Test.hs
+++ b/Test.hs
@@ -19,6 +19,11 @@ interface' "im.pidgin.purple.PurpleService" Nothing "im.pidgin.purple.PurpleInte
     , "BlistGetBuddies" =:: Return ''Ints
     , "BuddyGetAlias" =:: ''Int32 :-> Return ''String ]
 
+-- Compile-only test.
+interface' "org.freedesktop.secrets" (Just "/org/freedesktop/secrets") "org.freedesktop.Secret.Service" Nothing
+    [ "OpenSession" =:: ''String :-> ''Variant :-> Returns [''Variant, ''ObjectPath]
+    ]
+
 main = do
   [account, buddy] <- getArgs
   let obj = "/im/pidgin/purple/PurpleObject" 

--- a/dbus-th.cabal
+++ b/dbus-th.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dbus-th
-version:             0.1.3.0
+version:             0.1.3.1
 synopsis:            TemplateHaskell generator of DBus bindings
 description:         This package provides functions to easily generate bindings for
                      DBus functions. See Test.hs for examples.


### PR DESCRIPTION
As title says. This PR also bumps the package version and Changelog.

I tried to guess the coding style to try and keep it consistent with the rest of the code.

I don't think it's useful to include the method call in `Test.hs` since that wouldn't test the codegen (which is tested through the compiler), but rather that the instance definition is correct.

Validation:

```
$ cabal repl
Build profile: -w ghc-9.2.4 -O1
In order, the following will be built (use -v for more details):
 - dbus-th-0.1.3.1 (lib) (first run)
./dbus-th.cabal has been changed. Re-configuring with most recently used
options. If this fails, please run configure manually.
Configuring library for dbus-th-0.1.3.1..
Preprocessing library for dbus-th-0.1.3.1..
GHCi, version 9.2.4: https://www.haskell.org/ghc/  :? for help
[1 of 1] Compiling DBus.TH.EDSL     ( DBus/TH/EDSL.hs, interpreted )
Ok, one module loaded.
ghci> :l Test.hs

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules:
        DBus.TH.EDSL
[1 of 2] Compiling DBus.TH.EDSL     ( DBus/TH/EDSL.hs, interpreted )
[2 of 2] Compiling Main             ( Test.hs, interpreted )
Ok, two modules loaded.
ghci> import DBus
ghci> import DBus.Client
ghci> c <- connectSession
ghci> openSession c "plain" (toVariant "")
Just (Variant "",ObjectPath "/org/freedesktop/secrets/session/s24")
```