### PR TITLE
Fix codegen for methods returning Unit

### DIFF
--- a/DBus/TH/EDSL.hs
+++ b/DBus/TH/EDSL.hs
@@ -201,7 +201,7 @@ function' busName mbObjectName ifaceName mbPrefix (Function name dbusName sig) =
         where
           returnValue :: [Name] -> Q Exp
           returnValue [t]
-            | t == ''() = [| return () |]
+            | t == ''() = [| () |]
             | otherwise = [| fromVariant (head (methodReturnBody res)) |]
           returnValue ts  = do
             patVars <- traverse newName $ ("a" ++) . show <$> [1..length ts]

--- a/Test.hs
+++ b/Test.hs
@@ -22,6 +22,7 @@ interface' "im.pidgin.purple.PurpleService" Nothing "im.pidgin.purple.PurpleInte
 -- Compile-only test.
 interface' "org.freedesktop.secrets" (Just "/org/freedesktop/secrets") "org.freedesktop.Secret.Service" Nothing
     [ "OpenSession" =:: ''String :-> ''Variant :-> Returns [''Variant, ''ObjectPath]
+    , "ItemChanged" =:: Return ''()
     ]
 
 main = do


### PR DESCRIPTION
My previous commit generated bad code for functions returned `()`. Sorry about that!

This should fix it!

I added an example to the Test file.